### PR TITLE
Refactoring + utils tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+*.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -12,5 +12,6 @@
     "maxlen": 120,
     "quotmark": "single",
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "laxbreak": true
 }

--- a/lib/error-builder.js
+++ b/lib/error-builder.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var os = require('os');
 var SourceLocator = require('./source-locator');
 
 module.exports = {
@@ -23,7 +24,7 @@ module.exports = {
             i++;
         }
         result.unshift(formatErrorMessage(message, pos.source));
-        return result.join('\n');
+        return result.join(os.EOL);
     }
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,11 +1,8 @@
 var mozilla = require('source-map');
 var SourceMapGenerator = mozilla.SourceMapGenerator;
-var btoa = require('btoa');
 var utils = require('./utils');
 var getSourceMap = utils.getSourceMap;
 var removeBuiltInSourceMap = utils.removeBuiltInSourceMap;
-
-var SOURCE_MAPPING_URL_COMMENT = '//# sourceMappingURL=data:application/json;base64,';
 
 function File(filename, useSourceMap) {
     this._content = [''];
@@ -75,14 +72,11 @@ File.prototype = {
     },
 
     render: function () {
-        var lines = this._content.concat();
+        var content = this._content.join('\n');
         if (this._map) {
-            if (lines[lines.length - 1] === '') {
-                lines.pop();
-            }
-            lines = lines.concat(SOURCE_MAPPING_URL_COMMENT + btoa(this._map.toString()));
+            content = utils.joinContentAndSourceMap(content, this._map);
         }
-        return lines.join('\n');
+        return content;
     }
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,3 +1,4 @@
+var os = require('os');
 var mozilla = require('source-map');
 var SourceMapGenerator = mozilla.SourceMapGenerator;
 var utils = require('./utils');
@@ -72,7 +73,7 @@ File.prototype = {
     },
 
     render: function () {
-        var content = this._content.join('\n');
+        var content = this._content.join(os.EOL);
         if (this._map) {
             content = utils.joinContentAndSourceMap(content, this._map);
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,16 @@
 var os = require('os');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var atob = require('atob');
 var btoa = require('btoa');
 
 var SOURCE_MAPPING_URL_COMMENT = '//# sourceMappingURL=data:application/json;base64,';
 
 module.exports = {
+    /**
+     * @param {String|String[]} content
+     * @return {SourceMapConsumer}
+     */
     getSourceMap: function (content) {
        return Array.isArray(content)
             ? getFromLastLine_(content)
@@ -22,7 +27,11 @@ module.exports = {
         }
     },
 
-    // Remove last line if starts with '//# sourceMappingURL='
+    /**
+     * Remove last line if it starts with '//# sourceMappingURL='
+     * @param {String|String[]} content
+     * @return {String|String[]} content without sourcemap string
+     */
     removeBuiltInSourceMap: function (content) {
         return Array.isArray(content)
             ? removeFromLines_(content.concat())
@@ -42,18 +51,18 @@ module.exports = {
         }
     },
 
-    ///
+    /**
+     * @param {String} content
+     * @param {SourceMapGenerator} sourceMap
+     * @return {String}
+     */
     joinContentAndSourceMap: function (content, sourceMap) {
-        var sourceMapLine = SOURCE_MAPPING_URL_COMMENT + btoa(stringify_(sourceMap));
-        return [content.trimRight(), sourceMapLine].join(os.EOL);
-
-        ///
-        function stringify_(sourceMap) {
-            var str = sourceMap.toString();
-            return str === {}.toString() // '[object Object]'
-                ? JSON.stringify(sourceMap)
-                : str;
+        if (!(sourceMap instanceof SourceMapGenerator)) {
+            throw new Error('sourceMap should be an instance of SourceMapGenerator');
         }
+
+        var sourceMapLine = SOURCE_MAPPING_URL_COMMENT + btoa(sourceMap.toString());
+        return [content.trimRight(), sourceMapLine].join(os.EOL);
     }
 };
 
@@ -78,7 +87,7 @@ function split(text) {
 
     return {
         content: pieces[0].trimRight(),
-        sourceMap: pieces[1].trim()
+        sourceMap: pieces[1].trimRight()
     };
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,13 +5,23 @@ var SOURCE_MAPPING_URL_COMMENT = '//# sourceMappingURL=data:application/json;bas
 
 module.exports = {
     getSourceMap: function (content) {
-        var lines = Array.isArray(content) ? content : getLines(content);
-        if (lines[lines.length - 1].indexOf(SOURCE_MAPPING_URL_COMMENT) === 0) {
-            return new SourceMapConsumer(
-                JSON.parse(atob(lines[lines.length - 1].substr(SOURCE_MAPPING_URL_COMMENT.length)))
-            );
-        } else {
-            return null;
+       return Array.isArray(content)
+            ? getFromLastLine_(content)
+            : getFromText_(content);
+
+        ///
+        function getFromLastLine_(lines) {
+            return mkSourceMap_(split(lines[lines.length - 1]).sourceMap);
+        }
+
+        ///
+        function getFromText_(text) {
+            return mkSourceMap_(split(text).sourceMap);
+        }
+
+        ///
+        function mkSourceMap_(str) {
+            return str && new SourceMapConsumer(JSON.parse(atob(str)));
         }
     },
 
@@ -23,7 +33,7 @@ module.exports = {
 
         ///
         function removeFromLines_(lines) {
-            if (lines[lines.length - 1].indexOf(SOURCE_MAPPING_URL_COMMENT) === 0) {
+            if (split(lines[lines.length - 1]).sourceMap) {
                 lines.pop();
             }
             return lines;
@@ -31,14 +41,27 @@ module.exports = {
 
         ///
         function removeFromText_(text) {
-            var pieces = text.split(SOURCE_MAPPING_URL_COMMENT);
-            return pieces.length === 1 || getLines(pieces[1]).length > 1
-                ? text
-                : pieces[0].trimRight();
+            return split(text).content;
         }
     }
 };
 
-function getLines(text) {
-    return text.split(/\r\n|\r|\n/);
+/**
+ * Split text into content and source map parts
+ * @param {String} text
+ * @return {Object} {content: 'content without source map', sourceMap: 'base64 encoded source map'|null}
+ */
+function split(text) {
+    var pieces = text.split(SOURCE_MAPPING_URL_COMMENT);
+    if (pieces.length === 1 || /(\r\n|\r|\n)\s*\S+/.test(pieces[1])) {
+        return {
+            content: text,
+            sourceMap: null
+        };
+    }
+
+    return {
+        content: pieces[0].trimRight(),
+        sourceMap: pieces[1].trim()
+    };
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+var os = require('os');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var atob = require('atob');
 var btoa = require('btoa');
@@ -44,7 +45,7 @@ module.exports = {
     ///
     joinContentAndSourceMap: function (content, sourceMap) {
         var sourceMapLine = SOURCE_MAPPING_URL_COMMENT + btoa(stringify_(sourceMap));
-        return [content.trimRight(), sourceMapLine].join('\n');
+        return [content.trimRight(), sourceMapLine].join(os.EOL);
 
         ///
         function stringify_(sourceMap) {
@@ -59,7 +60,7 @@ module.exports = {
 /**
  * @typedef {Object} ContentAndSourceMap
  * @property {String} content
- * @property {String|null} sourceMap base 64 encoded source map
+ * @property {String|null} sourceMap base64 encoded source map
  */
 /**
  * Split text into content and source map parts

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,12 +14,28 @@ module.exports = {
             return null;
         }
     },
+
+    // Remove last line if starts with '//# sourceMappingURL='
     removeBuiltInSourceMap: function (content) {
-        var lines = Array.isArray(content) ? content.concat() : getLines(content);
-        if (lines[lines.length - 1].indexOf(SOURCE_MAPPING_URL_COMMENT) === 0) {
-            lines.pop(); // //# sourceMappingURL=
+        return Array.isArray(content)
+            ? removeFromLines_(content.concat())
+            : removeFromText_(content);
+
+        ///
+        function removeFromLines_(lines) {
+            if (lines[lines.length - 1].indexOf(SOURCE_MAPPING_URL_COMMENT) === 0) {
+                lines.pop();
+            }
+            return lines;
         }
-        return lines;
+
+        ///
+        function removeFromText_(text) {
+            var pieces = text.split(SOURCE_MAPPING_URL_COMMENT);
+            return pieces.length === 1 || getLines(pieces[1]).length > 1
+                ? text
+                : pieces[0].trimRight();
+        }
     }
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var atob = require('atob');
+var btoa = require('btoa');
 
 var SOURCE_MAPPING_URL_COMMENT = '//# sourceMappingURL=data:application/json;base64,';
 
@@ -11,17 +12,12 @@ module.exports = {
 
         ///
         function getFromLastLine_(lines) {
-            return mkSourceMap_(split(lines[lines.length - 1]).sourceMap);
+            return mkSourceMap(split(lines[lines.length - 1]).sourceMap);
         }
 
         ///
         function getFromText_(text) {
-            return mkSourceMap_(split(text).sourceMap);
-        }
-
-        ///
-        function mkSourceMap_(str) {
-            return str && new SourceMapConsumer(JSON.parse(atob(str)));
+            return mkSourceMap(split(text).sourceMap);
         }
     },
 
@@ -43,13 +39,32 @@ module.exports = {
         function removeFromText_(text) {
             return split(text).content;
         }
+    },
+
+    ///
+    joinContentAndSourceMap: function (content, sourceMap) {
+        var sourceMapLine = SOURCE_MAPPING_URL_COMMENT + btoa(stringify_(sourceMap));
+        return [content.trimRight(), sourceMapLine].join('\n');
+
+        ///
+        function stringify_(sourceMap) {
+            var str = sourceMap.toString();
+            return str === {}.toString() // '[object Object]'
+                ? JSON.stringify(sourceMap)
+                : str;
+        }
     }
 };
 
 /**
+ * @typedef {Object} ContentAndSourceMap
+ * @property {String} content
+ * @property {String|null} sourceMap base 64 encoded source map
+ */
+/**
  * Split text into content and source map parts
  * @param {String} text
- * @return {Object} {content: 'content without source map', sourceMap: 'base64 encoded source map'|null}
+ * @return {ContentAndSourceMap}
  */
 function split(text) {
     var pieces = text.split(SOURCE_MAPPING_URL_COMMENT);
@@ -64,4 +79,9 @@ function split(text) {
         content: pieces[0].trimRight(),
         sourceMap: pieces[1].trim()
     };
+}
+
+///
+function mkSourceMap(base64Str) {
+    return base64Str && new SourceMapConsumer(JSON.parse(atob(base64Str)));
 }

--- a/tests/file.test.js
+++ b/tests/file.test.js
@@ -1,5 +1,4 @@
 var path = require('path');
-require('chai').should();
 var File = require('../lib/file');
 var SourceLocator = require('../lib/source-locator');
 

--- a/tests/file.test.js
+++ b/tests/file.test.js
@@ -1,3 +1,4 @@
+var os = require('os');
 var path = require('path');
 var File = require('../lib/file');
 var SourceLocator = require('../lib/source-locator');
@@ -214,7 +215,7 @@ function hasSourceMap(source) {
 }
 
 function stripSourceMap(source) {
-    var lines = source.split('\n');
+    var lines = source.split(os.EOL);
     lines.pop();
-    return lines.join('\n') + '\n';
+    return lines.join(os.EOL) + '\n';
 }

--- a/tests/mocha.opts
+++ b/tests/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--require test/setup

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,1 @@
+require('chai').should();

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -65,18 +65,20 @@ describe('Utils', function() {
         });
 
         it('should return same content if no source map line', function() {
-            var lines = utils.removeBuiltInSourceMap(['line1', 'line2'].join('\n'));
-            lines.should.be.deep.equal(['line1', 'line2'].join('\n'));
+            var content = utils.removeBuiltInSourceMap(['line1', 'line2'].join('\n'));
+            content.should.be.deep.equal(['line1', 'line2'].join('\n'));
         });
 
         it('should return same lines if source map line is not the last one', function() {
-            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line']);
-            lines.should.be.deep.equal(['line1', 'line2']);
+            var expectedLines = ['line1', 'line2', SOURCE_MAP_STRING, 'some-line'];
+            var lines = utils.removeBuiltInSourceMap(expectedLines);
+            lines.should.be.deep.equal(expectedLines);
         });
 
         it('should return same content if source map line is not the last one', function() {
-            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line'].join('\n'));
-            lines.should.be.deep.equal(['line1', 'line2'].join('\n'));
+            var expectedContent = ['line1', 'line2', SOURCE_MAP_STRING, 'some-line'].join('\n');
+            var content = utils.removeBuiltInSourceMap(expectedContent);
+            content.should.be.deep.equal(expectedContent);
         });
     });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect,
     utils = require('../lib/utils');
 
 describe('Utils', function() {
-    var someSourceMap = {
+    var SOME_SOURCE_MAP = {
             version: 3,
             file: 'min.js',
             names: ['bar', 'baz', 'n'],
@@ -13,17 +13,17 @@ describe('Utils', function() {
             sourceRoot: 'http://example.com/www/js/',
             mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
         },
-        STUB_SOURCE_MAP = new SourceMapConsumer(someSourceMap),
-        SOURCE_MAP_STRING = '//# sourceMappingURL=data:application/json;base64,' + btoa(JSON.stringify(someSourceMap));
+        STUB_SOURCE_MAP = new SourceMapConsumer(SOME_SOURCE_MAP),
+        SOURCE_MAP_LINE = '//# sourceMappingURL=data:application/json;base64,' + btoa(JSON.stringify(SOME_SOURCE_MAP));
 
     describe('getSourceMap()', function() {
         it('should return source map for bunch of lines', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING]);
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE]);
             sourceMap.should.be.deep.equal(STUB_SOURCE_MAP);
         });
 
         it('should return source map for string content', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING].join('\n'));
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE].join('\n'));
             sourceMap.should.be.deep.equal(STUB_SOURCE_MAP);
         });
 
@@ -38,24 +38,24 @@ describe('Utils', function() {
         });
 
         it('should return null if sourcemap is not the last line', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line']);
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE, 'some-line']);
             expect(sourceMap).to.be.equal(null);
         });
 
         it('should return null if sourcemap is not the last line in content', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line'].join('\n'));
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE, 'some-line'].join('\n'));
             expect(sourceMap).to.be.equal(null);
         });
     });
 
     describe('removeBuiltInSourceMap()', function() {
         it('should return source map line', function() {
-            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING]);
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_LINE]);
             lines.should.be.deep.equal(['line1', 'line2']);
         });
 
         it('should return content without source map line', function() {
-            var content = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING].join('\n'));
+            var content = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_LINE].join('\n'));
             content.should.be.deep.equal(['line1', 'line2'].join('\n'));
         });
 
@@ -70,15 +70,22 @@ describe('Utils', function() {
         });
 
         it('should return same lines if source map line is not the last one', function() {
-            var expectedLines = ['line1', 'line2', SOURCE_MAP_STRING, 'some-line'];
+            var expectedLines = ['line1', 'line2', SOURCE_MAP_LINE, 'some-line'];
             var lines = utils.removeBuiltInSourceMap(expectedLines);
             lines.should.be.deep.equal(expectedLines);
         });
 
         it('should return same content if source map line is not the last one', function() {
-            var expectedContent = ['line1', 'line2', SOURCE_MAP_STRING, 'some-line'].join('\n');
+            var expectedContent = ['line1', 'line2', SOURCE_MAP_LINE, 'some-line'].join('\n');
             var content = utils.removeBuiltInSourceMap(expectedContent);
             content.should.be.deep.equal(expectedContent);
+        });
+    });
+
+    describe('joinContentAndSourceMap()', function() {
+        it('should join content and source map', function() {
+            var result = utils.joinContentAndSourceMap(['line1', 'line2'].join('\n'), SOME_SOURCE_MAP);
+            result.should.be.equal(['line1', 'line2', SOURCE_MAP_LINE].join('\n'));
         });
     });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,4 +1,5 @@
-var expect = require('chai').expect,
+var os = require('os'),
+    expect = require('chai').expect,
     btoa = require('btoa'),
     SourceMapConsumer = require('source-map').SourceMapConsumer,
 
@@ -23,7 +24,7 @@ describe('Utils', function() {
         });
 
         it('should return source map for string content', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE].join('\n'));
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE].join(os.EOL));
             sourceMap.should.be.deep.equal(STUB_SOURCE_MAP);
         });
 
@@ -33,7 +34,7 @@ describe('Utils', function() {
         });
 
         it('should return null if no sourcemap in content', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2'].join('\n'));
+            var sourceMap = utils.getSourceMap(['line1', 'line2'].join(os.EOL));
             expect(sourceMap).to.be.equal(null);
         });
 
@@ -43,7 +44,7 @@ describe('Utils', function() {
         });
 
         it('should return null if sourcemap is not the last line in content', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE, 'some-line'].join('\n'));
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_LINE, 'some-line'].join(os.EOL));
             expect(sourceMap).to.be.equal(null);
         });
     });
@@ -55,8 +56,8 @@ describe('Utils', function() {
         });
 
         it('should return content without source map line', function() {
-            var content = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_LINE].join('\n'));
-            content.should.be.deep.equal(['line1', 'line2'].join('\n'));
+            var content = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_LINE].join(os.EOL));
+            content.should.be.deep.equal(['line1', 'line2'].join(os.EOL));
         });
 
         it('should return same lines if no source map line', function() {
@@ -65,8 +66,8 @@ describe('Utils', function() {
         });
 
         it('should return same content if no source map line', function() {
-            var content = utils.removeBuiltInSourceMap(['line1', 'line2'].join('\n'));
-            content.should.be.deep.equal(['line1', 'line2'].join('\n'));
+            var content = utils.removeBuiltInSourceMap(['line1', 'line2'].join(os.EOL));
+            content.should.be.deep.equal(['line1', 'line2'].join(os.EOL));
         });
 
         it('should return same lines if source map line is not the last one', function() {
@@ -76,7 +77,7 @@ describe('Utils', function() {
         });
 
         it('should return same content if source map line is not the last one', function() {
-            var expectedContent = ['line1', 'line2', SOURCE_MAP_LINE, 'some-line'].join('\n');
+            var expectedContent = ['line1', 'line2', SOURCE_MAP_LINE, 'some-line'].join(os.EOL);
             var content = utils.removeBuiltInSourceMap(expectedContent);
             content.should.be.deep.equal(expectedContent);
         });
@@ -84,8 +85,8 @@ describe('Utils', function() {
 
     describe('joinContentAndSourceMap()', function() {
         it('should join content and source map', function() {
-            var result = utils.joinContentAndSourceMap(['line1', 'line2'].join('\n'), SOME_SOURCE_MAP);
-            result.should.be.equal(['line1', 'line2', SOURCE_MAP_LINE].join('\n'));
+            var result = utils.joinContentAndSourceMap(['line1', 'line2'].join(os.EOL), SOME_SOURCE_MAP);
+            result.should.be.equal(['line1', 'line2', SOURCE_MAP_LINE].join(os.EOL));
         });
     });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,82 @@
+var expect = require('chai').expect,
+    btoa = require('btoa'),
+    SourceMapConsumer = require('source-map').SourceMapConsumer,
+
+    utils = require('../lib/utils');
+
+describe('Utils', function() {
+    var someSourceMap = {
+            version: 3,
+            file: 'min.js',
+            names: ['bar', 'baz', 'n'],
+            sources: ['one.js', 'two.js'],
+            sourceRoot: 'http://example.com/www/js/',
+            mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+        },
+        STUB_SOURCE_MAP = new SourceMapConsumer(someSourceMap),
+        SOURCE_MAP_STRING = '//# sourceMappingURL=data:application/json;base64,' + btoa(JSON.stringify(someSourceMap));
+
+    describe('getSourceMap()', function() {
+        it('should return source map for bunch of lines', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING]);
+            sourceMap.should.be.deep.equal(STUB_SOURCE_MAP);
+        });
+
+        it('should return source map for string content', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING].join('\n'));
+            sourceMap.should.be.deep.equal(STUB_SOURCE_MAP);
+        });
+
+        it('should return null if no sourcemap in lines', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2']);
+            expect(sourceMap).to.be.equal(null);
+        });
+
+        it('should return null if no sourcemap in content', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2'].join('\n'));
+            expect(sourceMap).to.be.equal(null);
+        });
+
+        it('should return null if sourcemap is not the last line', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line']);
+            expect(sourceMap).to.be.equal(null);
+        });
+
+        it('should return null if sourcemap is not the last line in content', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line'].join('\n'));
+            expect(sourceMap).to.be.equal(null);
+        });
+    });
+
+    describe('removeBuiltInSourceMap()', function() {
+        it('should return source map line', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING]);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return content without source map line', function() {
+            var content = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING].join('\n'));
+            content.should.be.deep.equal(['line1', 'line2'].join('\n'));
+        });
+
+        it('should return same lines if no source map line', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2']);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return same content if no source map line', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2'].join('\n'));
+            lines.should.be.deep.equal(['line1', 'line2'].join('\n'));
+        });
+
+        it('should return same lines if source map line is not the last one', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line']);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return same content if source map line is not the last one', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', SOURCE_MAP_STRING, 'some-line'].join('\n'));
+            lines.should.be.deep.equal(['line1', 'line2'].join('\n'));
+        });
+    });
+});


### PR DESCRIPTION
- добавил новый утилитарный метод:  `joinContentAndSourceMap`, вынес логику склеивания в него
- поправил функцию `removeBuiltInSourceMap`, чтобы она адекватно обрабатывала ситуации, когда строка source map не последняя в тексте + теперь если на входе текст, то и на  выходе текст, а не массив строк
- поправил `getSourceMap` и `removeBuiltInSourceMap` в сторону лучшей производительности - если на входе текст, то мы не разбиваем его на строки, а просто выдираем строку с source map
- написал тестов на utils
