### PR TITLE
Correct space handling in source map comment

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var atob = require('atob');
 var btoa = require('btoa');
 
-var SOURCE_MAPPING_URL_COMMENT = '# sourceMappingURL=data:application/json;base64,';
+var SOURCE_MAPPING_URL_COMMENT = 'sourceMappingURL=data:application/json;base64,';
 
 module.exports = {
     /**
@@ -66,7 +66,7 @@ module.exports = {
         opts = opts || {};
         opts.comment = opts.comment || 'inline';
 
-        var sourceMapComment = SOURCE_MAPPING_URL_COMMENT + btoa(sourceMap.toString());
+        var sourceMapComment = '# ' + SOURCE_MAPPING_URL_COMMENT + btoa(sourceMap.toString());
         var sourceMapLine = opts.comment === 'inline'
                 ? '//' + sourceMapComment
                 : '/*' + sourceMapComment + '*/';
@@ -86,7 +86,7 @@ module.exports = {
  * @return {ContentAndSourceMap}
  */
 function split(text) {
-    var pieces = text.split(new RegExp('/(?:/|\\*)\\s*' + SOURCE_MAPPING_URL_COMMENT));
+    var pieces = text.split(new RegExp('/(?:/|\\*)\\s*#\\s*' + SOURCE_MAPPING_URL_COMMENT));
     if (pieces.length === 1 || /(\r\n|\r|\n)\s*\S+/.test(pieces[1])) {
         return {
             content: text,

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -9,8 +9,8 @@ var os = require('os'),
 describe('Utils', function() {
     var SOURCE_MAP_GENERATOR = new SourceMapGenerator(),
         SOURCE_MAP_CONSUMER = new SourceMapConsumer(JSON.parse(SOURCE_MAP_GENERATOR.toString())),
-        SOURCE_MAP_COMMENT = '# sourceMappingURL=data:application/json;base64,' + btoa(SOURCE_MAP_GENERATOR.toString()),
-        SOURCE_MAP_LINE = '//' + SOURCE_MAP_COMMENT;
+        SOURCE_MAP_COMMENT = 'sourceMappingURL=data:application/json;base64,' + btoa(SOURCE_MAP_GENERATOR.toString()),
+        SOURCE_MAP_LINE = '//# ' + SOURCE_MAP_COMMENT;
 
     describe('getSourceMap()', function() {
         it('should return source map for bunch of lines', function() {
@@ -43,8 +43,28 @@ describe('Utils', function() {
             expect(sourceMap).to.be.equal(null);
         });
 
-        it('should return source map wrapped with multiline comment', function() {
-            var sourceMap = utils.getSourceMap(['line1', 'line2', '/*' + SOURCE_MAP_COMMENT + '*/'].join(os.EOL));
+        it('should return source map wrapped with block comment', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', '/*# ' + SOURCE_MAP_COMMENT + '*/'].join(os.EOL));
+            sourceMap.should.be.deep.equal(SOURCE_MAP_CONSUMER);
+        });
+
+        it('should return source map if no space in comment', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', '//#' + SOURCE_MAP_COMMENT].join(os.EOL));
+            sourceMap.should.be.deep.equal(SOURCE_MAP_CONSUMER);
+        });
+
+        it('should return source map if no space in block comment', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', '/*#' + SOURCE_MAP_COMMENT + '*/'].join(os.EOL));
+            sourceMap.should.be.deep.equal(SOURCE_MAP_CONSUMER);
+        });
+
+        it('should return source map if there are spaces betwen // and #', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', '// #' + SOURCE_MAP_COMMENT].join(os.EOL));
+            sourceMap.should.be.deep.equal(SOURCE_MAP_CONSUMER);
+        });
+
+        it('should return source map if there are spaces betwen /* and #', function() {
+            var sourceMap = utils.getSourceMap(['line1', 'line2', '/* #' + SOURCE_MAP_COMMENT + '*/'].join(os.EOL));
             sourceMap.should.be.deep.equal(SOURCE_MAP_CONSUMER);
         });
     });
@@ -82,8 +102,28 @@ describe('Utils', function() {
             content.should.be.deep.equal(expectedContent);
         });
 
-        it('should return lines without source map line if source map wrapped with multiline comment', function() {
-            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', '/*' + SOURCE_MAP_COMMENT + '*/']);
+        it('should return lines without source map line if source map wrapped with block comment', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', '/*# ' + SOURCE_MAP_COMMENT + '*/']);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return lines without source map line if no space in comment', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', '//#' + SOURCE_MAP_COMMENT]);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return lines without source map line if no space in block comment', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', '/*#' + SOURCE_MAP_COMMENT + '*/']);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return lines without source map line if there are spaces between // and #', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', '// #' + SOURCE_MAP_COMMENT]);
+            lines.should.be.deep.equal(['line1', 'line2']);
+        });
+
+        it('should return lines without source map line if there are spaces between /* and #', function() {
+            var lines = utils.removeBuiltInSourceMap(['line1', 'line2', '/* #' + SOURCE_MAP_COMMENT + '*/']);
             lines.should.be.deep.equal(['line1', 'line2']);
         });
     });
@@ -112,7 +152,7 @@ describe('Utils', function() {
                     SOURCE_MAP_GENERATOR,
                     {comment: 'block'}
                 );
-            result.should.be.equal(['line1', 'line2', '/*' + SOURCE_MAP_COMMENT + '*/'].join(os.EOL));
+            result.should.be.equal(['line1', 'line2', '/*# ' + SOURCE_MAP_COMMENT + '*/'].join(os.EOL));
         });
     });
 });


### PR DESCRIPTION
postcss creates source map comment without any spaces in it: `/*#sourceMappingURL=...`
We should correctly handle such case.